### PR TITLE
For nested joins, there was an issue where calls to the inner most so…

### DIFF
--- a/src/query_translation.jl
+++ b/src/query_translation.jl
@@ -386,6 +386,7 @@ function replace_transparent_identifier_in_anonym_func(ex::Expr, names_to_put_in
 	end
 end
 
+# translates (:a, :((b.c).d)) to :(((a.b).c).d)
 function shift_access!(sym::Symbol, ex::Expr)
 	while ex.args[1] isa Expr
 		ex = ex.args[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -455,6 +455,18 @@ end
 @test q["Sally"]==5
 @test q["Kirk"]==2
 
+q = @from i in source_df begin
+    @let j = i.name
+    @let k = i.children
+    @let l = i.age
+    @select {a=j, b=k, c=l}
+    @collect DataFrame
+end
+
+@test q.a == ["John", "Sally", "Kirk"]
+@test q.b == [3, 5, 2]
+@test q.c == [23., 42., 59.]
+
 @test @count(source_df)==3
 @test @count(source_df, i->i.children>3)==1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -463,6 +463,18 @@ end
 @test q["Sally"]==5
 @test q["Kirk"]==2
 
+q = @from i in source_df begin
+    @let j = i.name
+    @let k = i.children
+    @let l = i.age
+    @select {a=j, b=k, c=l}
+    @collect DataFrame
+end
+
+@test q.a == ["John", "Sally", "Kirk"]
+@test q.b == [3, 5, 2]
+@test q.c == [23., 42., 59.]
+
 @test @count(source_df)==3
 @test @count(source_df, i->i.children>3)==1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,14 @@ end
         @test !Query.iscall(:(map(1,2,3,4)), :map, 3)
     end
 
+    @testset "shift_access!" begin
+        ex = Expr(:., :c, QuoteNode(:d))
+        Query.shift_access!(:b, ex)
+        @test ex == :((b.c).d)
+        Query.shift_access!(:a, ex)
+        @test ex == :(((a.b).c).d)
+    end
+
 source_df = DataFrame(name=["John", "Sally", "Kirk"], age=[23., 42., 59.], children=[3,5,2])
 
 q = @from i in source_df begin
@@ -454,18 +462,6 @@ end
 @test q["John"]==3
 @test q["Sally"]==5
 @test q["Kirk"]==2
-
-q = @from i in source_df begin
-    @let j = i.name
-    @let k = i.children
-    @let l = i.age
-    @select {a=j, b=k, c=l}
-    @collect DataFrame
-end
-
-@test q.a == ["John", "Sally", "Kirk"]
-@test q.b == [3, 5, 2]
-@test q.c == [23., 42., 59.]
 
 @test @count(source_df)==3
 @test @count(source_df, i->i.children>3)==1


### PR DESCRIPTION
…urce got translated like :(a.(b.c)) while proper access should look like :((a.b).c). This commit adds an invert_getproperty_access translate function that performs the translation.

Fixes a query like:
```julia
using Query, DataFrames
mf = (senID=[1,2,3], leftNeighbor=[1,2,3], linearPosition=[1,2,3], word=["as", "the", "sailor"], simplecat=[1,2,3])
@from i in mf begin
    @join i11 in mf on (i.senID, i.leftNeighbor) equals (i11.senID, i11.linearPosition)
    @join i12 in mf on (i11.senID, i11.leftNeighbor) equals (i12.senID, i12.linearPosition)
    @join i13 in mf on (i12.senID, i12.leftNeighbor) equals (i13.senID, i13.linearPosition)
    @where i13.word == "as"
    @group i by i.simplecat into g
    @select {Key = key(g), Count = length(g)}
    @collect DataFrame
end
```