### PR TITLE
Remove unnecessary Documenter dependency.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
 julia 0.7
 TableTraits 0.3.1
-Documenter 0.19.3
 IterableTables 0.8.2
 DataValues 0.4.4
 MacroTools 0.4.4


### PR DESCRIPTION
Hi, as you may know we are working on a breaking release of Documenter. Therefore, we are putting upperbounds on the packages that have Documenter as a direct dependency (https://github.com/JuliaLang/METADATA.jl/pull/19162) but I noticed that this package have a dependency on Documenter for no reason. This PR removes that.