### PR TITLE
Simplify macro rewriters and avoid some prospective bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+*.idea/
 docs/build/
 docs/site/
 docs/Manifest.toml

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ IterableTables 0.8.2
 DataValues 0.4.4
 MacroTools 0.4.4
 QueryOperators 0.6.0
+MLStyle 0.2.4

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -5,6 +5,7 @@ import IterableTables
 using DataValues
 using MacroTools: postwalk
 using QueryOperators
+using MLStyle
 
 export @from, @query, @count, Grouping, key
 


### PR DESCRIPTION
You may want to check this clean implementation of @select:
https://github.com/thautwarm/Query.jl/blob/34f6dbaf5aba156fafa9d60335126a7795f6b676/src/table_query_macros.jl#L49
```julia
macro select(args...)
    foldl(args, init=NamedTuple()) do prev, arg
        @match arg begin
            :(everywhere()) => :_

            ::Int && if arg > 0 end =>
                :( merge($prev, QueryOperators.NamedTupleUtilities.select(_, Val(keys(_)[$arg]))) )

            ::Int && if arg < 0 end =>
                let sel = ifelse(prev == NamedTuple(), :_, prev)
                    :( QueryOperators.NamedTupleUtilities.remove($sel, Val(keys($sel)[-$arg])) )
                end
            ::QuoteNode =>
                :( merge($prev, QueryOperators.NamedTupleUtilities.select(_, Val($(arg)))) )
     ...
end
``` 

Also, there're some prospective bugs that've been avoided, e.g., quoted `"` in fieldname of dataframes.
```julia
df |> @select(startwith("\"a\""))
```

