### PR TITLE
Fix `sink` type for IndexedTables.jl in docs

### DIFF
--- a/docs/src/sinks.md
+++ b/docs/src/sinks.md
@@ -105,7 +105,7 @@ the `TS` type.
 
 ## IndexedTable
 
-The statement `@collect IndexedTable` will materialize the query results
+The statement `@collect table` will materialize the query results
 into a new `IndexedTables.IndexedTable` instance. This statement only
 works if the last projection statement transformed the results into a
 `NamedTuple`, for example by using the `{}` syntax. The last column of


### PR DESCRIPTION
The default constructor for an `IndexedTable` is not `IndexedTable` but the function `table`. `@collect IndexedTable` will throw an error but `@collect table` will return the correct result.