### PR TITLE
Add @summarize (alias @summarise) for grouped and whole-table aggregation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Query.jl v1.2.0 Release Notes
+* Add @summarize (alias @summarise) for grouped and whole-table aggregation
+
 # Query.jl v1.1.0 Release Notes
 * Add @pivot_wider and @pivot_longer
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # Query.jl v1.2.0 Release Notes
-* Add @summarize (alias @summarise) for grouped and whole-table aggregation
+* Add @summarize for grouped and whole-table aggregation
 
 # Query.jl v1.1.0 Release Notes
 * Add @pivot_wider and @pivot_longer

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ IndexedTables = "6deec6e2-d858-57c5-ab9b-e6ca5bd20e43"
 [compat]
 IterableTables = "0.8.2, 0.9, 0.10, 0.11, 1"
 julia = "1.10"
-QueryOperators = "1"
+QueryOperators = "1.1"
 DataValues = "0.4.4, 0.5, 1"
 MacroTools = "0.4.4, 0.5"
 

--- a/docs/src/standalonequerycommands.md
+++ b/docs/src/standalonequerycommands.md
@@ -368,7 +368,7 @@ println(q)
 
 ## The `@summarize` command
 
-The `@summarize` command has the form `source |> @summarize(args...)`. `source` can be any source that can be queried. Each argument from `args...` must have the form `name = expression`. Inside each expression, `_` refers to the collection of rows that is being aggregated, so functions that operate on a whole column or group like `mean(_.age)`, `length(_)` or `key(_)` can be used. `@summarise` is an alias for `@summarize`.
+The `@summarize` command has the form `source |> @summarize(args...)`. `source` can be any source that can be queried. Each argument from `args...` must have the form `name = expression`. Inside each expression, `_` refers to the collection of rows that is being aggregated, so functions that operate on a whole column or group like `mean(_.age)`, `length(_)` or `key(_)` can be used.
 
 When `source` is the output of a `@groupby` command, `@summarize` returns one row per group. The grouping key columns are automatically prepended to the aggregate columns: a scalar grouping key becomes a column named `key`, and a grouping key that is a named tuple contributes one column per field. If an aggregate has the same name as a key column, the aggregate replaces that key column.
 

--- a/docs/src/standalonequerycommands.md
+++ b/docs/src/standalonequerycommands.md
@@ -366,6 +366,58 @@ println(q)
    3 │ Cherry    1000   1000.8     false
 ``` 
 
+## The `@summarize` command
+
+The `@summarize` command has the form `source |> @summarize(args...)`. `source` can be any source that can be queried. Each argument from `args...` must have the form `name = expression`. Inside each expression, `_` refers to the collection of rows that is being aggregated, so functions that operate on a whole column or group like `mean(_.age)`, `length(_)` or `key(_)` can be used. `@summarise` is an alias for `@summarize`.
+
+When `source` is the output of a `@groupby` command, `@summarize` returns one row per group. The grouping key columns are automatically prepended to the aggregate columns: a scalar grouping key becomes a column named `key`, and a grouping key that is a named tuple contributes one column per field. If an aggregate has the same name as a key column, the aggregate replaces that key column.
+
+When `source` is not grouped, the whole table is treated as a single group and `@summarize` returns a stream with exactly one row and no key columns.
+
+#### Example
+
+```jldoctest
+using Query, DataFrames, Statistics
+
+df = DataFrame(name=["John", "Sally", "Kirk"], age=[23., 42., 59.], children=[3,2,2])
+
+x = df |>
+    @groupby(_.children) |>
+    @summarize(n = length(_), mean_age = mean(_.age)) |>
+    DataFrame
+
+println(x)
+
+# output
+
+2×3 DataFrame
+ Row │ key    n      mean_age
+     │ Int64  Int64  Float64
+─────┼────────────────────────
+   1 │     3      1      23.0
+   2 │     2      2      50.5
+```
+
+The next example applies `@summarize` to an ungrouped source, which aggregates the whole table into a single row:
+
+```jldoctest
+using Query, DataFrames, Statistics
+
+df = DataFrame(name=["John", "Sally", "Kirk"], age=[23., 42., 59.], children=[3,2,2])
+
+x = df |> @summarize(n = length(_), mean_age = mean(_.age)) |> DataFrame
+
+println(x)
+
+# output
+
+1×2 DataFrame
+ Row │ n      mean_age
+     │ Int64  Float64
+─────┼─────────────────
+   1 │     3   41.3333
+```
+
 ## The `@dropna` command
 
 The `@dropna` command has the form `source |> @dropna(columns...)`. `source` can be any source that can be queried and that has a table structure. If `@dropna()` is called without any arguments, it will drop any row from `source` that has a missing `NA` value in _any_ of its columns. Alternatively one can pass a list of column names to `@dropna`, in which case it will only drop rows that have a `NA` value in one of those columns.

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -11,7 +11,7 @@ export @map, @filter, @groupby, @orderby, @orderby_descending, @unique,
 	@thenby, @thenby_descending, @groupjoin, @join, @mapmany, @take, @drop,
 	@pivot_longer, @pivot_wider
 
-export @select, @rename, @mutate, @disallowna, @dropna, @replacena
+export @select, @rename, @mutate, @summarize, @summarise, @disallowna, @dropna, @replacena
 
 # The following is a backwards compat fix
 export @dissallowna

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -11,7 +11,7 @@ export @map, @filter, @groupby, @orderby, @orderby_descending, @unique,
 	@thenby, @thenby_descending, @groupjoin, @join, @mapmany, @take, @drop,
 	@pivot_longer, @pivot_wider
 
-export @select, @rename, @mutate, @summarize, @summarise, @disallowna, @dropna, @replacena
+export @select, @rename, @mutate, @summarize, @disallowna, @dropna, @replacena
 
 # The following is a backwards compat fix
 export @dissallowna

--- a/src/table_query_macros.jl
+++ b/src/table_query_macros.jl
@@ -328,8 +328,6 @@ If an aggregate has the same name as a key column, the aggregate wins.
 Applied to an ungrouped source, `@summarize` treats the whole table as a single
 group and produces a stream with exactly one row and no key columns.
 
-`@summarise` is an alias.
-
 ```
 julia> df = DataFrame(k=[1,1,2], x=[3.0,2.0,1.0])
 
@@ -344,13 +342,4 @@ julia> df |> @groupby(_.k) |> @summarize(m = mean(_.x), n = length(_)) |> DataFr
 """
 macro summarize(args...)
     return _summarize_macro_impl("@summarize", args)
-end
-
-"""
-    @summarise(args...)
-
-Alias for [`@summarize`](@ref).
-"""
-macro summarise(args...)
-    return _summarize_macro_impl("@summarise", args)
 end

--- a/src/table_query_macros.jl
+++ b/src/table_query_macros.jl
@@ -231,3 +231,126 @@ macro replacena(arg, args...)
         return :( Query.@mutate( $( ( :( $(columns[i]) = our_get(_.$(columns[i]), $(replacement_values[i]))  ) for i=1:length(columns) )... )   ) )
     end
 end
+
+# Internal marker used as the key of the keyless Grouping that the ungrouped
+# @summarize path wraps its source in.
+struct _SummarizeUngroupedKey end
+
+_grouping_key(g::QueryOperators.Grouping) = QueryOperators.key(g)
+
+_key_namedtuple(k::NamedTuple) = k                        # multi-column grouping key: splat fields in
+_key_namedtuple(::_SummarizeUngroupedKey) = NamedTuple()  # ungrouped: no key columns
+_key_namedtuple(k) = (key = k,)                           # scalar key: column named `key`
+
+# Lazy one-element enumerable used by the ungrouped @summarize path: on first
+# iterate it collects the source rows, wraps them in a keyless Grouping (so
+# that `_.x` column access works exactly as in the grouped path) and yields
+# the single aggregated row.
+struct EnumerableSummarizeAll{T,S,Q<:Function} <: QueryOperators.Enumerable
+    source::S
+    f::Q
+end
+
+Base.eltype(::Type{EnumerableSummarizeAll{T,S,Q}}) where {T,S,Q} = T
+Base.IteratorSize(::Type{<:EnumerableSummarizeAll}) = Base.HasLength()
+Base.length(::EnumerableSummarizeAll) = 1
+
+function Base.iterate(iter::EnumerableSummarizeAll{T,S,Q}) where {T,S,Q}
+    TS = eltype(iter.source)
+    elements = Base.collect(TS, iter.source)
+    g = QueryOperators.Grouping{_SummarizeUngroupedKey,TS}(_SummarizeUngroupedKey(), elements)
+    return iter.f(g), nothing
+end
+
+Base.iterate(::EnumerableSummarizeAll, state) = nothing
+
+function summarize(source, f::Function, f_expr::Expr)
+    q = QueryOperators.query(source)
+    return _summarize(q, eltype(q), f, f_expr)
+end
+
+# Grouped input: one output row per group, as a lazy map over the groups.
+_summarize(q, ::Type{<:QueryOperators.Grouping}, f::Function, f_expr::Expr) =
+    QueryOperators.map(q, f, f_expr)
+
+# Ungrouped input: the whole source is treated as a single keyless group,
+# producing a stream of exactly one row (with no key columns).
+function _summarize(q, ::Type{TS}, f::Function, f_expr::Expr) where {TS}
+    TG = QueryOperators.Grouping{_SummarizeUngroupedKey,TS}
+    T = Base._return_type(f, Tuple{TG})
+    return EnumerableSummarizeAll{T,typeof(q),typeof(f)}(q, f)
+end
+
+function _summarize_macro_impl(macro_name, args)
+    source = nothing
+    agg_args = args
+    if !isempty(args) && !(args[1] isa Expr && args[1].head == :(=))
+        source = args[1]
+        agg_args = args[2:end]
+    end
+
+    isempty(agg_args) && error("$macro_name requires at least one name = expression argument.")
+
+    for arg in agg_args
+        (arg isa Expr && arg.head == :(=) && length(arg.args) == 2 && arg.args[1] isa Symbol) ||
+            error("Invalid argument `$arg` to $macro_name: every argument must have the form `name = expression`.")
+    end
+
+    agg_nt = Expr(:tuple, Expr(:parameters,
+        (Expr(:kw, arg.args[1], arg.args[2]) for arg in agg_args)...))
+
+    body = :( Base.merge(Query._key_namedtuple(Query._grouping_key(_)), $agg_nt) )
+    f = helper_replace_anon_func_syntax(body)
+    q_f = Expr(:quote, f)
+
+    if source === nothing
+        i_var = gensym(:source)
+        return :( $i_var -> Query.summarize($i_var, $f, $q_f) ) |> esc
+    else
+        return :( Query.summarize($source, $f, $q_f) ) |> esc
+    end
+end
+
+"""
+    @summarize(args...)
+
+Aggregate a table into summary rows, dplyr-style. It has the form
+`source |> @summarize(args...)`. Each argument from `args...` must have the
+form `name = expression`. Inside each expression, `_` refers to the collection
+of rows being aggregated, so for example `mean(_.x)`, `length(_)` and `key(_)`
+all work.
+
+Applied to the output of `@groupby`, `@summarize` produces one row per group,
+with the grouping key columns prepended: a scalar grouping key becomes a column
+named `key`, and a named-tuple grouping key contributes one column per field.
+If an aggregate has the same name as a key column, the aggregate wins.
+
+Applied to an ungrouped source, `@summarize` treats the whole table as a single
+group and produces a stream with exactly one row and no key columns.
+
+`@summarise` is an alias.
+
+```
+julia> df = DataFrame(k=[1,1,2], x=[3.0,2.0,1.0])
+
+julia> df |> @groupby(_.k) |> @summarize(m = mean(_.x), n = length(_)) |> DataFrame
+2×3 DataFrame
+ Row │ key    m        n
+     │ Int64  Float64  Int64
+─────┼───────────────────────
+   1 │     1      2.5      2
+   2 │     2      1.0      1
+```
+"""
+macro summarize(args...)
+    return _summarize_macro_impl("@summarize", args)
+end
+
+"""
+    @summarise(args...)
+
+Alias for [`@summarize`](@ref).
+"""
+macro summarise(args...)
+    return _summarize_macro_impl("@summarise", args)
+end

--- a/src/table_query_macros.jl
+++ b/src/table_query_macros.jl
@@ -232,55 +232,6 @@ macro replacena(arg, args...)
     end
 end
 
-# Internal marker used as the key of the keyless Grouping that the ungrouped
-# @summarize path wraps its source in.
-struct _SummarizeUngroupedKey end
-
-_grouping_key(g::QueryOperators.Grouping) = QueryOperators.key(g)
-
-_key_namedtuple(k::NamedTuple) = k                        # multi-column grouping key: splat fields in
-_key_namedtuple(::_SummarizeUngroupedKey) = NamedTuple()  # ungrouped: no key columns
-_key_namedtuple(k) = (key = k,)                           # scalar key: column named `key`
-
-# Lazy one-element enumerable used by the ungrouped @summarize path: on first
-# iterate it collects the source rows, wraps them in a keyless Grouping (so
-# that `_.x` column access works exactly as in the grouped path) and yields
-# the single aggregated row.
-struct EnumerableSummarizeAll{T,S,Q<:Function} <: QueryOperators.Enumerable
-    source::S
-    f::Q
-end
-
-Base.eltype(::Type{EnumerableSummarizeAll{T,S,Q}}) where {T,S,Q} = T
-Base.IteratorSize(::Type{<:EnumerableSummarizeAll}) = Base.HasLength()
-Base.length(::EnumerableSummarizeAll) = 1
-
-function Base.iterate(iter::EnumerableSummarizeAll{T,S,Q}) where {T,S,Q}
-    TS = eltype(iter.source)
-    elements = Base.collect(TS, iter.source)
-    g = QueryOperators.Grouping{_SummarizeUngroupedKey,TS}(_SummarizeUngroupedKey(), elements)
-    return iter.f(g), nothing
-end
-
-Base.iterate(::EnumerableSummarizeAll, state) = nothing
-
-function summarize(source, f::Function, f_expr::Expr)
-    q = QueryOperators.query(source)
-    return _summarize(q, eltype(q), f, f_expr)
-end
-
-# Grouped input: one output row per group, as a lazy map over the groups.
-_summarize(q, ::Type{<:QueryOperators.Grouping}, f::Function, f_expr::Expr) =
-    QueryOperators.map(q, f, f_expr)
-
-# Ungrouped input: the whole source is treated as a single keyless group,
-# producing a stream of exactly one row (with no key columns).
-function _summarize(q, ::Type{TS}, f::Function, f_expr::Expr) where {TS}
-    TG = QueryOperators.Grouping{_SummarizeUngroupedKey,TS}
-    T = Base._return_type(f, Tuple{TG})
-    return EnumerableSummarizeAll{T,typeof(q),typeof(f)}(q, f)
-end
-
 function _summarize_macro_impl(macro_name, args)
     source = nothing
     agg_args = args
@@ -299,15 +250,15 @@ function _summarize_macro_impl(macro_name, args)
     agg_nt = Expr(:tuple, Expr(:parameters,
         (Expr(:kw, arg.args[1], arg.args[2]) for arg in agg_args)...))
 
-    body = :( Base.merge(Query._key_namedtuple(Query._grouping_key(_)), $agg_nt) )
+    body = :( Base.merge(Query.QueryOperators._key_namedtuple(Query.QueryOperators.key(_)), $agg_nt) )
     f = helper_replace_anon_func_syntax(body)
     q_f = Expr(:quote, f)
 
     if source === nothing
         i_var = gensym(:source)
-        return :( $i_var -> Query.summarize($i_var, $f, $q_f) ) |> esc
+        return :( $i_var -> Query.QueryOperators.summarize(Query.QueryOperators.query($i_var), $f, $q_f) ) |> esc
     else
-        return :( Query.summarize($source, $f, $q_f) ) |> esc
+        return :( Query.QueryOperators.summarize(Query.QueryOperators.query($source), $f, $q_f) ) |> esc
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("test_dplyr-syntax.jl")
 include("test_pipesyntax.jl")
 include("test_macros.jl")
 include("test_standalone.jl")
+include("test_summarize.jl")
 
 @run_package_tests
 

--- a/test/test_summarize.jl
+++ b/test/test_summarize.jl
@@ -41,10 +41,6 @@
     # collect into a DataFrame
     @test DataFrame(df |> @groupby(_.k) |> @summarize(m = mean(_.x))) ==
         DataFrame(key=[1,2], m=[1.5,4.0])
-
-    # @summarise alias
-    @test df |> @groupby(_.k) |> @summarise(m = mean(_.x)) |> collect ==
-        [(key=1, m=1.5), (key=2, m=4.0)]
 end
 
 @testitem "Summarize Macro ungrouped" begin
@@ -84,9 +80,6 @@ end
     # grouped source-first form
     g = df |> @groupby(_.k)
     @test @summarize(g, m = mean(_.x)) |> collect == [(key=1, m=1.5), (key=2, m=4.0)]
-
-    # source-first form of the alias
-    @test @summarise(df, n = length(_)) |> collect == [(n=3,)]
 end
 
 @testitem "Summarize Macro error cases" begin

--- a/test/test_summarize.jl
+++ b/test/test_summarize.jl
@@ -1,0 +1,126 @@
+@testitem "Summarize Macro grouped" begin
+    using DataFrames, Statistics
+
+    df = DataFrame(k=[1,1,2], x=[1.,2.,4.])
+
+    # single scalar key: key column named `key`, aggregates correct
+    @test df |> @groupby(_.k) |> @summarize(m = mean(_.x)) |> collect ==
+        [(key=1, m=1.5), (key=2, m=4.0)]
+
+    # length(_) and key(_) inside aggregate expressions
+    @test df |> @groupby(_.k) |> @summarize(n = length(_), k10 = key(_) * 10) |> collect ==
+        [(key=1, n=2, k10=10), (key=2, n=1, k10=20)]
+
+    # multi-key (NamedTuple key): key fields splat as columns in order
+    df2 = DataFrame(a=[1,1,2], b=["x","y","x"], v=[1,2,3])
+    @test df2 |> @groupby({_.a, _.b}) |> @summarize(s = sum(_.v)) |> collect ==
+        [(a=1, b="x", s=1), (a=1, b="y", s=2), (a=2, b="x", s=3)]
+
+    # collision: aggregate named `key` (scalar key case) — aggregate wins
+    @test df |> @groupby(_.k) |> @summarize(key = sum(_.x)) |> collect ==
+        [(key=3.0,), (key=4.0,)]
+
+    # collision: aggregate named like a key field (multi-key case) — aggregate wins
+    @test df2 |> @groupby({_.a, _.b}) |> @summarize(a = sum(_.v)) |> collect ==
+        [(a=1, b="x"), (a=2, b="y"), (a=3, b="x")]
+
+    # chaining after @summarize
+    @test df |> @groupby(_.k) |> @summarize(m = mean(_.x)) |>
+        @filter(_.m > 2) |> @orderby(_.m) |> collect == [(key=2, m=4.0)]
+
+    # closure over a local variable in an aggregate expression
+    c = 2.0
+    @test df |> @groupby(_.k) |> @summarize(m = mean(_.x) * c) |> collect ==
+        [(key=1, m=3.0), (key=2, m=8.0)]
+
+    # type stability: concrete NamedTuple eltype
+    r = df |> @groupby(_.k) |> @summarize(m = mean(_.x)) |> collect
+    @test eltype(r) == typeof((key=1, m=1.5))
+    @test isconcretetype(eltype(r))
+
+    # collect into a DataFrame
+    @test DataFrame(df |> @groupby(_.k) |> @summarize(m = mean(_.x))) ==
+        DataFrame(key=[1,2], m=[1.5,4.0])
+
+    # @summarise alias
+    @test df |> @groupby(_.k) |> @summarise(m = mean(_.x)) |> collect ==
+        [(key=1, m=1.5), (key=2, m=4.0)]
+end
+
+@testitem "Summarize Macro ungrouped" begin
+    using DataFrames, Statistics
+
+    df = DataFrame(k=[1,1,2], x=[1.,2.,4.])
+
+    # exactly one row, no key columns
+    @test df |> @summarize(m = mean(_.x), n = length(_)) |> collect ==
+        [(m=7/3, n=3)]
+
+    # result is still a composable stream
+    @test df |> @summarize(n = length(_)) |> @mutate(n2 = _.n * 2) |> collect ==
+        [(n=3, n2=6)]
+
+    # empty source: aggregates see an empty collection
+    empty_df = DataFrame(x=Float64[])
+    @test empty_df |> @summarize(n = length(_)) |> collect == [(n=0,)]
+
+    # type stability: concrete NamedTuple eltype
+    r = df |> @summarize(m = mean(_.x)) |> collect
+    @test eltype(r) == typeof((m=1.5,))
+    @test isconcretetype(eltype(r))
+
+    # collect into a DataFrame
+    @test DataFrame(df |> @summarize(n = length(_))) == DataFrame(n=[3])
+end
+
+@testitem "Summarize Macro source-first form" begin
+    using DataFrames, Statistics
+
+    df = DataFrame(k=[1,1,2], x=[1.,2.,4.])
+
+    # ungrouped source-first form
+    @test @summarize(df, m = mean(_.x), n = length(_)) |> collect == [(m=7/3, n=3)]
+
+    # grouped source-first form
+    g = df |> @groupby(_.k)
+    @test @summarize(g, m = mean(_.x)) |> collect == [(key=1, m=1.5), (key=2, m=4.0)]
+
+    # source-first form of the alias
+    @test @summarise(df, n = length(_)) |> collect == [(n=3,)]
+end
+
+@testitem "Summarize Macro error cases" begin
+    using DataFrames, Statistics
+
+    df = DataFrame(k=[1,1,2], x=[1.,2.,4.])
+
+    # no arguments at all
+    err = try
+        @eval df |> @summarize()
+        nothing
+    catch e
+        e
+    end
+    @test err isa LoadError
+    @test occursin("requires at least one name = expression argument", sprint(showerror, err.error))
+
+    # argument that is not name = expression (treated as source, no aggregates follow)
+    err = try
+        @eval df |> @summarize(mean(_.x))
+        nothing
+    catch e
+        e
+    end
+    @test err isa LoadError
+    @test occursin("requires at least one name = expression argument", sprint(showerror, err.error))
+
+    # invalid aggregate argument alongside a valid one
+    err = try
+        @eval df |> @summarize(m = mean(_.x), length(_))
+        nothing
+    catch e
+        e
+    end
+    @test err isa LoadError
+    @test occursin("must have the form `name = expression`", sprint(showerror, err.error))
+end


### PR DESCRIPTION
Adds a dplyr-style `@summarize` standalone macro, closing the biggest ergonomic gap identified in the recent API audit: grouped aggregation currently requires the two-step `@groupby(_.k) |> @map({k = key(_), m = mean(_.x)})` idiom with the explicit `key(_)` dance.

The operator layer lives in queryverse/QueryOperators.jl#54, which is merged and registered as **QueryOperators 1.1.0**; this PR sets `QueryOperators = "1.1"` compat and its full test suite passes against the registered release.

## Syntax

```julia
df |> @groupby(_.k) |> @summarize(m = mean(_.x), n = length(_))
```

Each argument must have the form `name = expression`. Inside each expression `_` is the collection of rows being aggregated, so `mean(_.x)`, `length(_)` and `key(_)` all work. Both the pipe form and the experimental source-first form (`@summarize(source, name = expr, ...)`) are supported, mirroring every other standalone macro.

## Semantics (dplyr's, in both cases)

- **Grouped input** (eltype `<: Grouping`): one output row per group, with the grouping key columns prepended and the aggregates after. The result stays a lazy stream — the grouped path is literally a `QueryOperators.map` over the groups, so it works on every source `@map` works on and remains representable in backend query plans as groupby+map.
- **Ungrouped input**: exactly **one** output row, with no key columns — the whole source is treated as a single keyless group. The result is still a stream (of one row), never a bare scalar, so `@summarize` stays a table→table arrow that composes with everything downstream (`|> @mutate(...)`, `|> DataFrame`, ...); users who want the bare named tuple write `|> first`. (The terminal-scalar design already exists as `@count` and is deliberately not duplicated.)
- **Scalar grouping key**: becomes a result column literally named `key` (rename afterwards with `@rename` if desired). A multi-column key from `@groupby({_.a, _.b})` splats its fields as columns `a, b, ...` in order.
- **Name collisions**: if an aggregate is named like a key column, `merge` is left-to-right, so **the aggregate wins** — documented and tested, not an error.
- **Errors**: `@summarize()` with no aggregates, or any argument that is not `name = expression`, throws a macro-expansion-time error naming the problem (deliberately stricter than `@mutate`).

## Implementation

The operator layer — `QueryOperators.summarize` with its eltype dispatch, the lazy one-row `EnumerableSummarizeAll` for the ungrouped path, the keyless-Grouping sentinel and the `_key_namedtuple` key normalization — lives in QueryOperators (queryverse/QueryOperators.jl#54), alongside the other enumerables and with the generic function open for backend methods. This PR contributes the macro layer: it emits one lambda via the existing `helper_replace_anon_func_syntax` pass (including `@mutate`'s closure-escaping approach) and expands to `QueryOperators.summarize(QueryOperators.query(source), f, f_expr)`.

- grouped → `QueryOperators.map(source, f, f_expr)` (lazy, unchanged rows-per-group semantics);
- ungrouped → a lazy one-element enumerable that, on first iterate, collects the rows and wraps them in a keyless `Grouping` (keyed by a private sentinel type, so a legitimate `nothing` grouping key stays unambiguous), then yields the single aggregated row. Eager materialization on first iterate has precedent in orderby/groupby.

Reusing `Grouping` for the ungrouped path means `_.x` column access goes through the existing `GroupColumnArrayView` machinery identically in both paths, and plain dispatch on the key type keeps both paths type-stable by construction, so `Base._return_type`-based eltype inference downstream still yields concrete row types.

A representative macroexpansion of `@summarize(m = mean(_.x), n = length(_))` (gensyms renamed for readability; `QO` = `Query.QueryOperators`, reached through the `Query` module because the expansion is fully escaped and users load `Query`, not `QueryOperators`):

```julia
source -> QO.summarize(QO.query(source),
    g -> Base.merge(QO._key_namedtuple(QO.key(g)),
                    (; m = mean(g.x), n = length(g))),
    :(g -> Base.merge(QO._key_namedtuple(QO.key(g)),
                      (; m = mean(g.x), n = length(g)))))
```

where the key normalization in QueryOperators is:

```julia
_key_namedtuple(k::NamedTuple) = k                        # multi-column key: splat fields
_key_namedtuple(::_SummarizeUngroupedKey) = NamedTuple()  # ungrouped: no key columns
_key_namedtuple(k) = (key = k,)                           # scalar key: column named `key`
```

## Testing and docs

- New `test/test_summarize.jl` testitems covering: scalar and multi-column keys, `length(_)`/`key(_)` in aggregates, both collision cases, chaining after `@summarize`, ungrouped single-row semantics (including empty sources and composability), closures over locals, concrete-eltype type stability for both paths, DataFrame collection, the source-first form, and the new error messages. The full testitem suite passes (20/20) against the registered QueryOperators 1.1.0, and `doctest(Query)` passes on Julia 1.12.
- New `@summarize` section in `docs/src/standalonequerycommands.md` with jldoctest examples (grouped and ungrouped), plus a NEWS.md entry under a new v1.2.0 heading.

## Backend pushdown follow-up (not in this PR)

SQL pushdown of `@summarize` is a separate follow-up in the backend repos: `@groupby(_.k)` without an element selector emits the simple 3-arg groupby, and QuerySQLite only registers the 5-arg form; QueryDuckDB would additionally need a translation branch for `_key_namedtuple`/`key`. The grouped path is deliberately just a `QueryableMap` after a groupby, so it stays fully representable in QueryableBackend plans; the ungrouped path can later be exposed to plan backends by overloading `QueryOperators.summarize(::Queryable, ...)` (SQL's aggregate without GROUP BY) — now possible because the generic function lives in QueryOperators. The fused group-and-reduce fast path is likewise out of scope: this sugar emits exactly the groupby+map pattern a future optimizing backend can pattern-match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
